### PR TITLE
CC-6641 - turn no-extra-parens off as it doesn't work well with wrap-iife

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = {
         'no-empty-character-class': 'error',
         'no-ex-assign': 'error',
         'no-extra-boolean-cast': 'error',
-        'no-extra-parens': 'error',
+        'no-extra-parens': 'off',
         'no-extra-semi': 'error',
         'no-func-assign': 'error',
         'no-inner-declarations': 'error',


### PR DESCRIPTION
Found a Possible bug in eslint when combining no-extra-parens and wrap-iife when returning an iife, e.g.

```
function() {
    return (function (){
    }());
}
```

is a false positive. 

The [documentation](http://eslint.org/docs/rules/no-extra-parens#rule-details) is clear that wrapped iifes will always be excluded when evaluating no-extra-parens but this is clearly not the case.

Thoughts all and particularly @qubyte?

