### PR TITLE
Proposal to remove newline per chained call as it disallows what I'd …

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,7 +169,7 @@ module.exports = {
         'new-parens': 'error',
         'newline-after-var': 'off',
         'newline-before-return': 'off',
-        'newline-per-chained-call': ['error', {ignoreChainWithDepth: 2}],
+        'newline-per-chained-call': 'off',
         'no-array-constructor': 'error',
         'no-bitwise': 'error',
         'no-continue': 'off',


### PR DESCRIPTION
…consider to the valid case of closing parentheses on a newline followed immediately by the chain

```
foo(() => {
    return bar;
}).then(() => {
    return baz;
}).then(() => {
    return spam;
}).then(() => {
    return eggs;
});
```

IMHO is preferable to

```
foo(() => {
    return bar;
})
    .then(() => {
        return baz;
    })
    .then(() => {
        return spam;
    })
    .then(() => {
        return eggs;
    });
```

I've see this overridden locally a few times already. 

Whilst I agree with the spirit of breaking long single line chains, the current application of the rule is net harmful.

Thoughts?
